### PR TITLE
Update to latest version 2.57.1, add Alias to apache config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ To run limesurvey in 80 port just:
 
 You are ready to go.
 
+### Environment variables
+
+To run limesurvey in a different http location set the `HTTP_LOCATION` environment variable.
+
+    docker run -d --name limesurvey -p 80:80 -e HTTP_LOCATION="surveys" crramirez/limesurvey:latest
+
+Limesurvey will then be available via http://localhost/surveys.
+
 ## Database in volumes
 
 If you want to preserve data in the event of a container deletion, or version upgrade, you can assign the MySQL data into a named volume:

--- a/apache_default
+++ b/apache_default
@@ -2,6 +2,7 @@ Listen 8080
 <VirtualHost *:*>
         ServerAdmin webmaster@localhost
 
+        Alias /${HTTP_LOCATION} /var/www/html
         DocumentRoot /var/www/html
         <Directory />
                 Options FollowSymLinks


### PR DESCRIPTION
According to issue #3 here the pull request. Update to latest LimeSurvey release plus an Alias in Apache which allows running in a different location like http://domain.com/surveys.